### PR TITLE
Fix query validation in middleware

### DIFF
--- a/middlewares/validateRequest.js
+++ b/middlewares/validateRequest.js
@@ -1,7 +1,9 @@
 const Joi = require("joi");
 
 const validateRequest = (schema) => (req, res, next) => {
-  const { error } = schema.validate(req.body || req.query);
+  const dataToValidate =
+    req.body && Object.keys(req.body).length > 0 ? req.body : req.query;
+  const { error } = schema.validate(dataToValidate);
   if (error) {
     return res.status(400).json({ message: error.details[0].message });
   }


### PR DESCRIPTION
## Summary
- properly validate query parameters in middleware when request body is empty

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684085ca6db483329db7d74cff2d73df