### PR TITLE
Fix middleware validation logic and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # .gitignore
 .env
 node_modules/
+dist/

--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -1,8 +1,11 @@
 import { Request, Response, NextFunction } from 'express';
 import { Schema } from 'joi';
 
-const validateRequest = (schema: Schema) => (req: Request, res: Response, next: NextFunction): void => {
-  const { error } = schema.validate(req.body || req.query);
+const validateRequest =
+  (schema: Schema) => (req: Request, res: Response, next: NextFunction): void => {
+    const dataToValidate =
+      req.body && Object.keys(req.body).length > 0 ? req.body : req.query;
+    const { error } = schema.validate(dataToValidate);
   
   if (error) {
     res.status(400).json({ message: error.details[0].message });

--- a/src/usecases/getMeteorsData.ts
+++ b/src/usecases/getMeteorsData.ts
@@ -4,19 +4,22 @@ import { Meteor } from '../interfaces/Meteor';
 import { MeteorQuery } from '../interfaces/MeteorQuery';
 import { MeteorResponse } from '../interfaces/MeteorResponse';
 
-const getMeteorsData = async (query: MeteorQuery): Promise<any> => {
+const getMeteorsData = async (
+  query: MeteorQuery
+): Promise<{ count: number } | { wereDangerousMeteors: boolean } | MeteorResponse[]> => {
   const { date, count, "were-dangerous-meteors": wereDangerousMeteors } = query;
-  
+
   if (!date) {
-    throw new Exception("Date is required", 400); // Или любое другое обработка
+    throw new Exception("Date is required", 400);
   }
   
   const startDate = date;
   const endDate = date;
 
-  const meteorsData: Record<string, Meteor[]> | null = await getMeteorsInfo(startDate, endDate);
-
-  console.log("meteorsData:", meteorsData);
+  const meteorsData: Record<string, Meteor[]> | null = await getMeteorsInfo(
+    startDate,
+    endDate
+  );
 
   if (!meteorsData) {
     throw new Exception("Failed to fetch data from NASA API", 500);


### PR DESCRIPTION
## Summary
- fix validation logic to check body before falling back to query
- refine getMeteorsData return type and remove debug logging
- ignore built files

## Testing
- `npm run lint` *(fails: config uses unsupported `env` option)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842b47e5e888332ac51b050c69dc1d1