### PR TITLE
Fix error handler typing

### DIFF
--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,11 +1,17 @@
 import { Request, Response, NextFunction } from 'express';
 import Exception from './utils/Exception';
 
-function globalErrorHandler(err: any, req: Request, res: Response, next: NextFunction): void {
-  const statusCode = err instanceof Exception ? err.statusCode : 500;
-  res.status(statusCode).json({
-    message: err.message,
-  });
+function globalErrorHandler(err: unknown, req: Request, res: Response, next: NextFunction): void {
+  if (err instanceof Exception) {
+    res.status(err.statusCode).json({
+      message: err.message,
+    });
+  } else {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    res.status(500).json({
+      message,
+    });
+  }
 }
 
 export default globalErrorHandler;


### PR DESCRIPTION
## Summary
- improve typing in global error handler
- fallback to default message for unknown errors

## Testing
- `npm run build`
- `npm run lint` *(fails: A config object is using the `env` key)*
- `npm test` *(fails: `no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_6842c12cd49483328439ecc18293e5c5