### PR TITLE
Add NASA API endpoints and views

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ Useful scripts are available for development:
 
 The application relies on the following variables:
 
-- `NASA_API_KEY` – your NASA API key for the Near Earth Objects feed.
+- `NASA_API_KEY` – your NASA API key.
 - `NASA_API_URL` – base URL for fetching meteor data.
 - `NASA_API_URL_PHOTOS` – base URL for retrieving the latest rover photos.
+- `NASA_API_URL_APOD` – Astronomy Picture of the Day endpoint.
+- `NASA_API_URL_EPIC` – EPIC imagery endpoint.
+- `NASA_API_URL_EONET` – Earth Observatory event endpoint.
+- `NASA_API_URL_DONKI` – DONKI space weather endpoint.
+- `NASA_API_URL_IMAGES` – NASA image search endpoint.
 - `PORT` – port number for the Express server (defaults to `4000`).
 
 Create a `.env` file or set these variables in your environment before starting the server.
@@ -43,6 +48,11 @@ Create a `.env` file or set these variables in your environment before starting 
 | GET    | `/meteors/html`           | Same as `/meteors` but renders an HTML page with the results. |
 | GET    | `/latest-rover-image-form`| Displays a form to request the latest Mars rover image. |
 | POST   | `/latest-rover-image`     | Accepts `userId`, `userName`, and `userAPIKey` in the body and shows the latest rover image. |
+| GET    | `/apod`                   | Shows the Astronomy Picture of the Day. |
+| GET    | `/epic`                   | Displays recent EPIC images. |
+| GET    | `/eonet`                  | Lists current natural events from EONET. |
+| GET    | `/donki`                  | Lists recent space weather notifications. |
+| GET    | `/image-search`           | Example NASA image search for "moon". |
 
 The server listens on the port specified by the `PORT` environment variable.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,11 @@ interface Config {
   nasaApiKey: string | undefined;
   nasaApiUrl: string | undefined;
   nasaApiUrlPhotos: string | undefined;
+  nasaApiUrlApod: string | undefined;
+  nasaApiUrlEpic: string | undefined;
+  nasaApiUrlEonet: string | undefined;
+  nasaApiUrlDonki: string | undefined;
+  nasaApiUrlImages: string | undefined;
   port: string | number;
 }
 
@@ -13,6 +18,11 @@ const config: Config = {
   nasaApiKey: process.env.NASA_API_KEY,
   nasaApiUrl: process.env.NASA_API_URL,
   nasaApiUrlPhotos: process.env.NASA_API_URL_PHOTOS,
+  nasaApiUrlApod: process.env.NASA_API_URL_APOD,
+  nasaApiUrlEpic: process.env.NASA_API_URL_EPIC,
+  nasaApiUrlEonet: process.env.NASA_API_URL_EONET,
+  nasaApiUrlDonki: process.env.NASA_API_URL_DONKI,
+  nasaApiUrlImages: process.env.NASA_API_URL_IMAGES,
   port: process.env.PORT || 4000,
 };
 

--- a/src/delivery/nasaRoutes.ts
+++ b/src/delivery/nasaRoutes.ts
@@ -1,6 +1,11 @@
 import express, { Request, Response, NextFunction } from 'express';
 import getMeteorsUseCase from '../usecases/getMeteorsData';
 import getLatestRoverImage from '../usecases/getLatestRoverImage';
+import getApod from '../usecases/getApod';
+import getEpicImages from '../usecases/getEpicImages';
+import getEonetEvents from '../usecases/getEonetEvents';
+import getDonkiNotifications from '../usecases/getDonkiNotifications';
+import searchNasaImages from '../usecases/searchNasaImages';
 import stringToBoolean from '../utils/booleanUtils';
 import { format } from 'date-fns';
 import config from '../config';
@@ -9,6 +14,10 @@ import latestRoverImageSchema from '../schemas/latestRoverImageSchema';
 import meteorsSchema from '../schemas/meteorsSchema';
 
 const router = express.Router();
+
+router.get('/', (req: Request, res: Response) => {
+  res.render('index.njk');
+});
 
 interface MeteorsQuery {
   date?: string;
@@ -87,5 +96,50 @@ router.post(
     }
   }
 );
+
+router.get('/apod', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const data = await getApod();
+    res.render('apod.njk', { data });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/epic', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const images = await getEpicImages();
+    res.render('epic.njk', { images });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/eonet', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const events = await getEonetEvents();
+    res.render('eonet.njk', { events });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/donki', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const notifications = await getDonkiNotifications();
+    res.render('donki.njk', { notifications });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/image-search', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const items = await searchNasaImages('moon');
+    res.render('imageSearch.njk', { items });
+  } catch (error) {
+    next(error);
+  }
+});
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import nunjucks from 'nunjucks';
-import meteorsRoute from './delivery/meteorsRoute';
+import nasaRoutes from './delivery/nasaRoutes';
 import globalErrorHandler from './errorHandler';
 import config from './config';
 
@@ -14,7 +14,7 @@ nunjucks.configure('views', {
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use(meteorsRoute);
+app.use(nasaRoutes);
 
 app.use(globalErrorHandler);
 

--- a/src/usecases/getApod.ts
+++ b/src/usecases/getApod.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import config from '../config';
+
+const getApod = async (): Promise<any> => {
+  const response = await axios.get(config.nasaApiUrlApod as string, {
+    params: { api_key: config.nasaApiKey },
+  });
+  return response.data;
+};
+
+export default getApod;

--- a/src/usecases/getDonkiNotifications.ts
+++ b/src/usecases/getDonkiNotifications.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import config from '../config';
+
+const getDonkiNotifications = async (): Promise<any[]> => {
+  const response = await axios.get(`${config.nasaApiUrlDonki}/notifications`, {
+    params: { api_key: config.nasaApiKey },
+  });
+  return response.data;
+};
+
+export default getDonkiNotifications;

--- a/src/usecases/getEonetEvents.ts
+++ b/src/usecases/getEonetEvents.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import config from '../config';
+
+const getEonetEvents = async (): Promise<any[]> => {
+  const response = await axios.get(config.nasaApiUrlEonet as string);
+  return response.data.events;
+};
+
+export default getEonetEvents;

--- a/src/usecases/getEpicImages.ts
+++ b/src/usecases/getEpicImages.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import config from '../config';
+
+const getEpicImages = async (): Promise<any[]> => {
+  const response = await axios.get(config.nasaApiUrlEpic as string, {
+    params: { api_key: config.nasaApiKey },
+  });
+  return response.data;
+};
+
+export default getEpicImages;

--- a/src/usecases/searchNasaImages.ts
+++ b/src/usecases/searchNasaImages.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import config from '../config';
+
+const searchNasaImages = async (query: string): Promise<any[]> => {
+  const response = await axios.get(config.nasaApiUrlImages as string, {
+    params: { q: query, media_type: 'image' },
+  });
+  return response.data.collection.items;
+};
+
+export default searchNasaImages;

--- a/src/views/apod.njk
+++ b/src/views/apod.njk
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>APOD</title>
+</head>
+<body>
+  <h1>{{ data.title }}</h1>
+  {% if data.media_type == 'image' %}
+  <img src="{{ data.url }}" alt="{{ data.title }}">
+  {% else %}
+  <a href="{{ data.url }}">{{ data.url }}</a>
+  {% endif %}
+  <p>{{ data.explanation }}</p>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/src/views/donki.njk
+++ b/src/views/donki.njk
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Space Weather</title>
+</head>
+<body>
+  <h1>DONKI Notifications</h1>
+  <ul>
+    {% for note in notifications %}
+    <li>{{ note.messageType }} - {{ note.messageID }}</li>
+    {% else %}
+    <li>No notifications.</li>
+    {% endfor %}
+  </ul>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/src/views/eonet.njk
+++ b/src/views/eonet.njk
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>EONET Events</title>
+</head>
+<body>
+  <h1>EONET Events</h1>
+  <ul>
+    {% for event in events %}
+    <li>{{ event.title }}</li>
+    {% else %}
+    <li>No events found.</li>
+    {% endfor %}
+  </ul>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/src/views/epic.njk
+++ b/src/views/epic.njk
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>EPIC Images</title>
+</head>
+<body>
+  <h1>EPIC Images</h1>
+  <ul>
+    {% for img in images %}
+    <li>{{ img.date }} - {{ img.image }}</li>
+    {% else %}
+    <li>No images found.</li>
+    {% endfor %}
+  </ul>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/src/views/imageSearch.njk
+++ b/src/views/imageSearch.njk
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Image Search</title>
+</head>
+<body>
+  <h1>Search Results</h1>
+  <ul>
+    {% for item in items %}
+    <li>{{ item.data[0].title }}</li>
+    {% else %}
+    <li>No items.</li>
+    {% endfor %}
+  </ul>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>NASA APIs</title>
+</head>
+<body>
+  <h1>NASA API Demos</h1>
+  <ul>
+    <li><a href="/meteors/html">Near Earth Objects</a></li>
+    <li><a href="/latest-rover-image-form">Latest Mars Rover Image</a></li>
+    <li><a href="/apod">Astronomy Picture of the Day</a></li>
+    <li><a href="/epic">EPIC Earth Images</a></li>
+    <li><a href="/eonet">EONET Events</a></li>
+    <li><a href="/donki">Space Weather (DONKI)</a></li>
+    <li><a href="/image-search">Image Search</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rename `meteorsRoute.ts` -> `nasaRoutes.ts`
- expose additional NASA API URLs in config
- create usecases for APOD, EPIC, EONET, DONKI and image search
- create routes and views for the new endpoints
- add index page with links
- document new environment variables and routes in README

## Testing
- `npm install`
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842c27256dc83329cb61f2411548b34