### PR TITLE
Add TypeScript ESLint plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,8 +11,11 @@ export default {
     "plugin:node/recommended",
     "plugin:promise/recommended",
     "plugin:security/recommended",
-    "plugin:import/recommended"
+    "plugin:import/recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   parserOptions: {
     ecmaVersion: 12,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.7.6",
         "@types/nunjucks": "^3.2.6",
+        "@typescript-eslint/eslint-plugin": "^8.9.0",
+        "@typescript-eslint/parser": "^8.9.0",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-node": "^11.1.0",
@@ -28,8 +30,7 @@
         "eslint-plugin-security": "^3.0.1",
         "globals": "^15.11.0",
         "husky": "^9.1.6",
-        "typescript": "^5.6.3",
-        "typescript-eslint": "^8.9.0"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4121,30 +4122,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.9.0.tgz",
-      "integrity": "sha512-AuD/FXGYRQyqyOBCpNLldMlsCGvmDNxptQ3Dp58/NXeB+FqyvTfXmMyba3PYa0Vi9ybnj7G8S/yd/4Cw8y47eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.9.0",
-        "@typescript-eslint/parser": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "globals": "^15.11.0",
     "husky": "^9.1.6",
     "typescript": "^5.6.3",
-    "typescript-eslint": "^8.9.0"
+    "@typescript-eslint/eslint-plugin": "^8.9.0",
+    "@typescript-eslint/parser": "^8.9.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@typescript-eslint` packages
- remove unused `typescript-eslint` meta-package
- configure ESLint to use the new parser and plugin

## Testing
- `npm run lint` *(fails: A config object is using the "env" key)*

------
https://chatgpt.com/codex/tasks/task_e_6842c84145c08332a288f752dbd9ba59