### PR TITLE
Remove unused config import

### DIFF
--- a/src/delivery/nasaRoutes.ts
+++ b/src/delivery/nasaRoutes.ts
@@ -8,7 +8,6 @@ import getDonkiNotifications from '../usecases/getDonkiNotifications';
 import searchNasaImages from '../usecases/searchNasaImages';
 import stringToBoolean from '../utils/booleanUtils';
 import { format } from 'date-fns';
-import config from '../config';
 import validateRequest from '../middlewares/validateRequest';
 import latestRoverImageSchema from '../schemas/latestRoverImageSchema';
 import meteorsSchema from '../schemas/meteorsSchema';


### PR DESCRIPTION
## Summary
- clean up `nasaRoutes.ts` to remove unused `config` import

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_6842c847c5f08332acd8331483c4349c